### PR TITLE
Update Potential-Collaborators.md

### DIFF
--- a/Potential-Collaborators.md
+++ b/Potential-Collaborators.md
@@ -4,10 +4,12 @@ We are working to gather a list of potential collaborators or others that may ha
 ## Companies
 - Cujo
 - Cisco
-- LiberyMutul (Virgin Media)
+- Liberty Global (Virgin Media)
 - WiFi equipment vendors
 - ISPs and WISPs
-- WiFi network operators
+- WiFi roaming network operators
+  - Boingo
+  - Ipass
 
 ## People
 - Kyle Johnson <Kyle.Johnson@charter.com>


### PR DESCRIPTION
Fixed "LibertyMutul" (sic) (an insurance company) to "Liberty Global" and added some example Wifi roaming network operators.